### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/perf/reqlatency.go
+++ b/perf/reqlatency.go
@@ -28,7 +28,7 @@ import (
 	"nanomsg.org/go-mangos/transport/all"
 )
 
-// LatencyServer is the server side -- very much equivalent to local_lat in
+// ReqRepLatencyServer is the server side -- very much equivalent to local_lat in
 // nanomsg/perf.  It does no measurement at all, just sends packets on the wire.
 func ReqRepLatencyServer(addr string, msgSize int, roundTrips int) {
 	s, err := rep.NewSocket()
@@ -64,7 +64,7 @@ func ReqRepLatencyServer(addr string, msgSize int, roundTrips int) {
 	}
 }
 
-// LatencyClient is the client side of the latency test.  It measures round
+// ReqRepLatencyClient is the client side of the latency test.  It measures round
 // trip times, and is the equivalent to nanomsg/perf/remote_lat.
 func ReqRepLatencyClient(addr string, msgSize int, roundTrips int) {
 	s, err := req.NewSocket()

--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -216,7 +216,7 @@ func (t *tlsTran) NewDialer(addr string, sock mangos.Socket) (mangos.PipeDialer,
 	return d, nil
 }
 
-// NewAccepter implements the Transport NewAccepter method.
+// NewListener implements the Transport NewAccepter method.
 func (t *tlsTran) NewListener(addr string, sock mangos.Socket) (mangos.PipeListener, error) {
 	var err error
 	l := &listener{sock: sock, opts: newOptions(t)}


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?