### PR TITLE
tls+tcp: support underlying TCP transport options (#346)

### DIFF
--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -34,6 +34,28 @@ func (o options) get(name string) (interface{}, error) {
 
 func (o options) set(name string, val interface{}) error {
 	switch name {
+	case mangos.OptionNoDelay:
+		fallthrough
+	case mangos.OptionKeepAlive:
+		switch v := val.(type) {
+		case bool:
+			o[name] = v
+			return nil
+		default:
+			return mangos.ErrBadValue
+		}
+	case mangos.OptionKeepAliveTime:
+		switch v := val.(type) {
+		case time.Duration:
+			if v.Nanoseconds() >= 0 {
+				o[name] = v
+				return nil
+			} else {
+				return mangos.ErrBadValue
+			}
+		default:
+			return mangos.ErrBadValue
+		}
 	case mangos.OptionTLSConfig:
 		switch v := val.(type) {
 		case *tls.Config:


### PR DESCRIPTION
This resolves #346 by adding the tls+tcp TCP options from tcp.go.